### PR TITLE
Selenium 4 Alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "babel-register": "6.26.0",
     "mocha": "5.2.0",
-    "selenium-webdriver": "3.6.0",
+    "selenium-webdriver": "4.0.0-alpha.1",
     "babel-plugin-syntax-trailing-function-commas": "6.22.0",
     "babel-plugin-transform-class-properties": "6.22.0",
     "babel-plugin-transform-es2015-modules-commonjs": "6.22.0",


### PR DESCRIPTION
We will release a fix for OSS (Selenium 3) bindings in a few days.
Till then you can use the W3C (selenium 4) alternative.

Signed-off-by: Varun Garg <varun.ga@browserstack.com>